### PR TITLE
chore: add `semantic-breaks.js` to format .mdx files via "one sentence per file"

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,6 +20,7 @@ install:
 lint:
     bun prettier --check .
 
-# fix lints using prettier
+# fix lints using prettier and format prose (semantic line breaks)
 fmt:
-    bun prettier --write .
+    bun run scripts/semantic-breaks.mjs
+    prettier --write .

--- a/scripts/semantic-breaks.mjs
+++ b/scripts/semantic-breaks.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+/**
+ * Adds semantic line breaks (one sentence per line) to MDX prose.
+ * Preserves: frontmatter, imports, JSX, code blocks, lists, headings, tables.
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { Glob } from "bun";
+
+// Match sentence endings followed by space and new sentence
+// Handles: uppercase starts, quotes, code, brackets, and lowercase (for brand names like "ricochet")
+const SENTENCE_BREAK = /([.!?]["']?)(\s+)(?=[A-Za-z"'`\[(])/g;
+
+function isProseLineStart(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+
+  // Skip these patterns
+  if (trimmed.startsWith("---")) return false; // frontmatter
+  if (trimmed.startsWith("```")) return false; // code fence
+  if (trimmed.startsWith("import ")) return false; // imports
+  if (trimmed.startsWith("export ")) return false; // exports
+  if (trimmed.startsWith("<")) return false; // JSX
+  if (trimmed.startsWith("{")) return false; // JSX expressions
+  if (trimmed.startsWith("#")) return false; // headings
+  if (trimmed.startsWith("-")) return false; // unordered lists
+  if (trimmed.startsWith("*")) return false; // unordered lists
+  if (trimmed.match(/^\d+\./)) return false; // ordered lists
+  if (trimmed.startsWith("|")) return false; // tables
+  if (trimmed.startsWith(">")) return false; // blockquotes
+  if (trimmed.startsWith("[")) return false; // link definitions
+
+  return true;
+}
+
+function processFile(content) {
+  const lines = content.split("\n");
+  const result = [];
+
+  let inFrontmatter = false;
+  let inCodeBlock = false;
+  let frontmatterCount = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Track frontmatter
+    if (trimmed === "---") {
+      frontmatterCount++;
+      inFrontmatter = frontmatterCount === 1;
+      result.push(line);
+      continue;
+    }
+
+    if (inFrontmatter) {
+      result.push(line);
+      continue;
+    }
+
+    // Track code blocks
+    if (trimmed.startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+      result.push(line);
+      continue;
+    }
+
+    if (inCodeBlock) {
+      result.push(line);
+      continue;
+    }
+
+    // Only process prose lines
+    if (isProseLineStart(line)) {
+      // Get the leading whitespace
+      const indent = line.match(/^(\s*)/)[1];
+      // Apply sentence breaks, preserving indentation
+      const formatted = trimmed.replace(SENTENCE_BREAK, "$1\n" + indent);
+      result.push(indent + formatted);
+    } else {
+      result.push(line);
+    }
+  }
+
+  return result.join("\n");
+}
+
+async function main() {
+  const pattern = process.argv[2] || "src/content/docs/**/*.mdx";
+  const glob = new Glob(pattern);
+
+  let changed = 0;
+  for await (const file of glob.scan(".")) {
+    const content = readFileSync(file, "utf-8");
+    const formatted = processFile(content);
+
+    if (content !== formatted) {
+      writeFileSync(file, formatted);
+      console.log(`✓ ${file}`);
+      changed++;
+    }
+  }
+
+  if (changed === 0) {
+    console.log("No changes needed");
+  } else {
+    console.log(`\nFormatted ${changed} file(s)`);
+  }
+}
+
+main().catch(console.error);

--- a/src/content/docs/v0-1/admin/configuration/1-authentication.mdx
+++ b/src/content/docs/v0-1/admin/configuration/1-authentication.mdx
@@ -2,7 +2,8 @@
 title: Authentication
 ---
 
-ricochet uses open ID connect for authentication. This allows you to bring your own identity provider to ricochet.
+ricochet uses open ID connect for authentication.
+This allows you to bring your own identity provider to ricochet.
 
 ricochet requires that your OIDC provider is able to provide the `email` and `profile` claim.
 

--- a/src/content/docs/v0-1/admin/installation/4-kubernetes.mdx
+++ b/src/content/docs/v0-1/admin/installation/4-kubernetes.mdx
@@ -70,7 +70,8 @@ Each bundle can be several megabytes, and a single app can accumulate many deplo
   You can start with smaller volumes and expand as needed, though resizing may involve some operational overhead.
 
 <Aside type="caution">
-  Ensure you have proper backups for your data PVC. Loss of this volume means
+  Ensure you have proper backups for your data PVC.
+  Loss of this volume means
   loss of all app and user content.
 </Aside>
 
@@ -107,6 +108,7 @@ The following fields can be set instance-wide through the Helm chart and should 
 - strategy
 
 <Aside type="note">
-  This feature is disabled by default for security. Enable it by setting
+  This feature is disabled by default for security.
+  Enable it by setting
   `allow_custom_k8s_config` to `true` in the Helm chart values.
 </Aside>

--- a/src/content/docs/v0-1/index.mdx
+++ b/src/content/docs/v0-1/index.mdx
@@ -13,7 +13,8 @@ import logo from "../../../assets/logo-25px-margin.svg";
 
 **ricochet** is the deployment platform for data scientists.
 
-Deploy R, Julia, and Python apps with a single command. Built-in authentication, access controls, and scheduling let you focus on your work, not infrastructure.
+Deploy R, Julia, and Python apps with a single command.
+Built-in authentication, access controls, and scheduling let you focus on your work, not infrastructure.
 
 ## Unsure where to start?
 
@@ -46,7 +47,8 @@ Deploy R, Julia, and Python apps with a single command. Built-in authentication,
 
 ## Why ricochet?
 
-Putting R, Julia, and Python into production shouldn't be hard. ricochet is a modern deployment platform tailored for data scientists who want to focus on their work, not infrastructure.
+Putting R, Julia, and Python into production shouldn't be hard.
+ricochet is a modern deployment platform tailored for data scientists who want to focus on their work, not infrastructure.
 
 - **Flexible infrastructure**: Run on Kubernetes, Docker, or VMs. Your infrastructure choices don't dictate your costs or capabilities.
 - **Built for teams of any size**: From individual homelabs to enterprise deployments, ricochet scales with you. Our [Homelab offering](/v0-1/admin/pricing/5-homelab) provides core features for personal projects, while enterprise features support production operations at scale.

--- a/src/content/docs/v0-1/user/content-items/1-content-items-overview.mdx
+++ b/src/content/docs/v0-1/user/content-items/1-content-items-overview.mdx
@@ -2,13 +2,15 @@
 title: Overview
 ---
 
-`ricochet` supports deploying R and Julia based content. Content items are categorize as either a **service** or as a **task** item.
+`ricochet` supports deploying R and Julia based content.
+Content items are categorize as either a **service** or as a **task** item.
 
 A **service** is one that requires an active runtime such as plumber or shiny.
 
 A **task** is one that runs to completion such as R/Julia scripts and Quarto documents.
 
-All tasks can be [scheduled](/v0-1/user/content-items/4-scheduled-content) (or [invoked via API](/v0-1/user/tasks/1-invoke)). A subset of tasks can be served as a [**static html** website](/v0-1/user/content-items/3-static-content)—for example R Markdown and Quarto documents or websites.
+All tasks can be [scheduled](/v0-1/user/content-items/4-scheduled-content) (or [invoked via API](/v0-1/user/tasks/1-invoke)).
+A subset of tasks can be served as a [**static html** website](/v0-1/user/content-items/3-static-content)—for example R Markdown and Quarto documents or websites.
 
 The below are content types supported by ricochet.
 

--- a/src/content/docs/v0-1/user/content-items/5-serverless-R.mdx
+++ b/src/content/docs/v0-1/user/content-items/5-serverless-R.mdx
@@ -4,11 +4,13 @@ title: "Serverless Functions"
 
 `ricochet` provides a serverless function runtime for R as the content type `serverless-r`.
 
-Serverless R enables users to create a simple R script with function definitions and deploy them as a RESTful API. The serverless function runtime abstracts away the hard work of converting R code into RESTful APIs so you can focus on deploying.
+Serverless R enables users to create a simple R script with function definitions and deploy them as a RESTful API.
+The serverless function runtime abstracts away the hard work of converting R code into RESTful APIs so you can focus on deploying.
 
 ## Usage
 
-The `serverless-r` content type requires an R script as the entrypoint which defines a list object called `routes`. The `routes` object is used to define the REST API endpoints.
+The `serverless-r` content type requires an R script as the entrypoint which defines a list object called `routes`.
+The `routes` object is used to define the REST API endpoints.
 
 Take an example `hello-world.R` file:
 
@@ -25,9 +27,11 @@ add2 <- function(x, y) {
 routes <- list(add2, hello_world)
 ```
 
-That's it! This will create a REST API with two routes: `/add2` and `hello_world`.
+That's it!
+This will create a REST API with two routes: `/add2` and `hello_world`.
 
-You can change the name of the endpoints by providing a named list. For example the route
+You can change the name of the endpoints by providing a named list.
+For example the route
 
 ```r
 routes <- list(
@@ -40,17 +44,24 @@ will create two endpoints called `/add-2` and `/hello-world`.
 
 ## Deploying
 
-To deploy a `serverless-r` item, create a new `_ricochet.toml` in your project using `ricochet::use_ricochet_toml()`. When selecting prompted to select the content type `"Serverless R"`. Then run `ricochet::deploy()`. Thats it!
+To deploy a `serverless-r` item, create a new `_ricochet.toml` in your project using `ricochet::use_ricochet_toml()`.
+When selecting prompted to select the content type `"Serverless R"`.
+Then run `ricochet::deploy()`.
+Thats it!
 
 ## Request Types
 
-The serverless R runtime supports only GET and POST requests. Function without any arguments are served as a **`GET`** request. If a function has aguments, it is accessible via `POST` request.
+The serverless R runtime supports only GET and POST requests.
+Function without any arguments are served as a **`GET`** request.
+If a function has aguments, it is accessible via `POST` request.
 
-By default all responses return (serialized) JSON. POST requests expect JSON in their bodies by default.
+By default all responses return (serialized) JSON.
+POST requests expect JSON in their bodies by default.
 
 ## Using (de)serializers
 
-It is possible to customize the type that responses are serialized as and how bodies are deserialized. Below are the available serializers and deserializers.
+It is possible to customize the type that responses are serialized as and how bodies are deserialized.
+Below are the available serializers and deserializers.
 
 - Serializers:
   - `csv`, `excel`, `feather`, `geojson`, `html`, `htmlwidget`, `jpeg`, `json`, `json-unboxed`, `octet`, `parquet`, `pdf`, `png`, `png`, `svg`, `svglite`, `text`, `tiff`, `tsv`, `yaml`.
@@ -71,7 +82,8 @@ list(
 
 You can return a csv file from your serverless functions by specifying the `serialize = "csv"` or you can also expect a csv file as your input by setting `deserialize = "csv"` as well.
 
-The below example creates two endpoints. `/penguins` returns the first 5 rows of the `penguins` data frame as a csv file and `/nrow` returns the number of rows sent in a csv file request.
+The below example creates two endpoints.
+`/penguins` returns the first 5 rows of the `penguins` data frame as a csv file and `/nrow` returns the number of rows sent in a csv file request.
 
 ```r
 routes <- list(
@@ -86,7 +98,8 @@ routes <- list(
 )
 ```
 
-The deployed serverless functions can be called using httr2. To read the csv file:
+The deployed serverless functions can be called using httr2.
+To read the csv file:
 
 ```r
 library(httr2)

--- a/src/content/docs/v0-1/user/deployment/1-ricochet-cli.mdx
+++ b/src/content/docs/v0-1/user/deployment/1-ricochet-cli.mdx
@@ -44,7 +44,8 @@ brew install ricochet
 
 ### Manual Installation
 
-We provide pre-built binaries for macOS, Linux, and Windows. Download from:
+We provide pre-built binaries for macOS, Linux, and Windows.
+Download from:
 
 ```
 https://hel1.your-objectstorage.com/ricochet-cli/$VERSION/ricochet-$VERSION-$OS_ARCH.tar.gz
@@ -77,11 +78,13 @@ Use the `login` command with the `-S` flag to specify the server URL:
 ricochet login -S https://try.ricochet.rs
 ```
 
-This opens your browser to complete authentication. Once authenticated, your credentials are stored locally and used for subsequent commands.
+This opens your browser to complete authentication.
+Once authenticated, your credentials are stored locally and used for subsequent commands.
 
 ### Multiple Instances
 
-You can authenticate with multiple ricochet servers. Each server's credentials are stored separately, keyed by the server URL.
+You can authenticate with multiple ricochet servers.
+Each server's credentials are stored separately, keyed by the server URL.
 
 To switch between servers, specify the `-S` flag with your commands:
 
@@ -132,7 +135,7 @@ If no `_ricochet.toml` file exists, the CLI walks you through an interactive set
 
 </Steps>
 
-After completing setup, a `_ricochet.toml` file is created in your project directory.  
+After completing setup, a `_ricochet.toml` file is created in your project directory.
 See [Using `_ricochet.toml`](/v0-1/user/deployment/2-ricochet-toml) for configuration details.
 
 ### Redeploying
@@ -142,4 +145,3 @@ Subsequent deployments use the existing `_ricochet.toml` configuration:
 ```bash
 ricochet deploy
 ```
-

--- a/src/content/docs/v0-1/user/deployment/2-ricochet-toml.mdx
+++ b/src/content/docs/v0-1/user/deployment/2-ricochet-toml.mdx
@@ -2,7 +2,8 @@
 title: Using `_ricochet.toml`
 ---
 
-Each deployment to ricochet is accompanied by a `_ricochet.toml` file. The `_ricochet.toml` file is used to set and keep track of metadata about your content item.
+Each deployment to ricochet is accompanied by a `_ricochet.toml` file.
+The `_ricochet.toml` file is used to set and keep track of metadata about your content item.
 
 ```toml
 [content]
@@ -36,7 +37,8 @@ and the following optional settings (depending on the content type):
 
 ## `content` settings
 
-The `[content]` section of the `_ricochet.toml` is required. It has the following required fields:
+The `[content]` section of the `_ricochet.toml` is required.
+It has the following required fields:
 
 | Field          | Description                                                                                                                                                                                                                                                                                                                                                           |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -49,11 +51,13 @@ The `[content]` section of the `_ricochet.toml` is required. It has the followin
 | `thumbnail`    | The relative path to an image to use as a thumbnail. Must be a png, jpg, or gif and 5mb or smaller.                                                                                                                                                                                                                                                                   |
 | `tags`         | An array of tags to be associated with the content item.                                                                                                                                                                                                                                                                                                              |
 
-Upon your first successful deployment, a unique content ID is created. The content ID is tracked in the `id` field.
+Upon your first successful deployment, a unique content ID is created.
+The content ID is tracked in the `id` field.
 
 ## `static` settings
 
-Some items such as R Markdown or Quarto may create static html websites. The `[static]` content settings can be used to specify which directory should be served from your content item.
+Some items such as R Markdown or Quarto may create static html websites.
+The `[static]` content settings can be used to specify which directory should be served from your content item.
 
 | Field        | Description                                                   |
 | ------------ | ------------------------------------------------------------- |
@@ -70,7 +74,8 @@ output_dir = "_site"
 
 ## `serve` settings
 
-Content items that require a running background process such as shiny or plumber are considered services. Use the `[serve]` settings to determine how the content scales.
+Content items that require a running background process such as shiny or plumber are considered services.
+Use the `[serve]` settings to determine how the content scales.
 
 The following settings can be set:
 
@@ -94,7 +99,9 @@ max_connections = 10
 
 ## `language` settings
 
-The language section of the `_ricochet.toml` is required. It contains two fields: `name` and `packages`. These specify which language the content item is using as well as how the dependencies are specified.
+The language section of the `_ricochet.toml` is required.
+It contains two fields: `name` and `packages`.
+These specify which language the content item is using as well as how the dependencies are specified.
 
 | Field      | Description                                                                                                                                 |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/v0-1/user/deployment/3-env-vars.mdx
+++ b/src/content/docs/v0-1/user/deployment/3-env-vars.mdx
@@ -4,12 +4,19 @@ title: "Environment Variables"
 
 Environment variables are key-value pairs that can be used to customize behavior at runtime.
 
-During development you may use a `.Renviron` or `.env` file to keep track of secrets. These files **should not** be deployed alongside your content item. Instead, set environment in the `ricochet` UI. Note that environment variables are encrypted at rest and only decrypted before starting an R or Julia process.
+During development you may use a `.Renviron` or `.env` file to keep track of secrets.
+These files **should not** be deployed alongside your content item.
+Instead, set environment in the `ricochet` UI.
+Note that environment variables are encrypted at rest and only decrypted before starting an R or Julia process.
 
-To add environment variables navigate to your content item's setting page at `https://ricochet.rs/content/{ID}/settings/env`. The `Key` is the name of the environment variable. `Value` is the value of the environment variable. Press save after adding new environment variables.
+To add environment variables navigate to your content item's setting page at `https://ricochet.rs/content/{ID}/settings/env`.
+The `Key` is the name of the environment variable.
+`Value` is the value of the environment variable.
+Press save after adding new environment variables.
 
 The new environment variables will be available to any new processes.
 
 ## Accessing environment variables
 
-To access environment variables in R, use `Sys.getenv("KEY_NAME")`. Or in Julia, access them via the built in dictionary `ENV["KEY_NAME"]`
+To access environment variables in R, use `Sys.getenv("KEY_NAME")`.
+Or in Julia, access them via the built in dictionary `ENV["KEY_NAME"]`

--- a/src/content/docs/v0-1/user/deployment/ricochet-toml.mdx
+++ b/src/content/docs/v0-1/user/deployment/ricochet-toml.mdx
@@ -2,7 +2,8 @@
 title: Using _ricochet.toml
 ---
 
-Each deployment to ricochet is accompanied by a `_ricochet.toml` file. The `_ricochet.toml` file is used to set and keep track of metadata about your content item.
+Each deployment to ricochet is accompanied by a `_ricochet.toml` file.
+The `_ricochet.toml` file is used to set and keep track of metadata about your content item.
 
 ```toml
 [content]
@@ -36,7 +37,8 @@ and the following optional settings (depending on the content type):
 
 ## 'content' Settings
 
-The `[content]` section of the `_ricochet.toml` is required. It has the following required fields:
+The `[content]` section of the `_ricochet.toml` is required.
+It has the following required fields:
 
 | Field          | Description                                                                                                                                                                                                                                                                                                                                                           |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -49,11 +51,13 @@ The `[content]` section of the `_ricochet.toml` is required. It has the followin
 | `thumbnail`    | The relative path to an image to use as a thumbnail. Must be a png, jpg, or gif and 5mb or smaller.                                                                                                                                                                                                                                                                   |
 | `tags`         | An array of tags to be associated with the content item.                                                                                                                                                                                                                                                                                                              |
 
-Upon your first successful deployment, a unique content ID is created. The content ID is tracked in the `id` field.
+Upon your first successful deployment, a unique content ID is created.
+The content ID is tracked in the `id` field.
 
 ## 'static' settings
 
-Some items such as R Markdown or Quarto may create static html websites. The `[static]` content settings can be used to specify which directory should be served from your content item.
+Some items such as R Markdown or Quarto may create static html websites.
+The `[static]` content settings can be used to specify which directory should be served from your content item.
 
 | Field        | Description                                                   |
 | ------------ | ------------------------------------------------------------- |
@@ -70,7 +74,8 @@ output_dir = "_site"
 
 ## 'serve' settings
 
-Content items that require a running background process such as shiny or plumber are considered services. Use the `[serve]` settings to determine how the content scales.
+Content items that require a running background process such as shiny or plumber are considered services.
+Use the `[serve]` settings to determine how the content scales.
 
 The following settings can be set:
 
@@ -94,7 +99,9 @@ max_connections = 10
 
 ## 'language' settings
 
-The language section of the `_ricochet.toml` is required. It contains two fields: `name` and `packages`. These specify which language the content item is using as well as how the dependencies are specified.
+The language section of the `_ricochet.toml` is required.
+It contains two fields: `name` and `packages`.
+These specify which language the content item is using as well as how the dependencies are specified.
 
 | Field      | Description                                                                                                                                 |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/v0-1/user/managing-content/scaling.mdx
+++ b/src/content/docs/v0-1/user/managing-content/scaling.mdx
@@ -4,7 +4,8 @@ title: Scaling
 
 Services that are deployed to ricochet such as [`{plumber}`](http://rplumber.io/) APIs, [Shiny](https://shiny.posit.co/r/) apps, or [Ambiorix](https://ambiorix.dev/docs/getting-started/) apps, dynamically auto-scale.
 
-You can control how the application scales via the scaling settings in the ricochet web UI, or via the `[serve]` settings in the `_ricochet.toml` file. The following settings are made available:
+You can control how the application scales via the scaling settings in the ricochet web UI, or via the `[serve]` settings in the `_ricochet.toml` file.
+The following settings are made available:
 
 - `min_instances`
 - `max_instances`
@@ -12,7 +13,8 @@ You can control how the application scales via the scaling settings in the ricoc
 - `max_connections`
 - `max_connection_age`
 
-See the section in `_ricochet.toml` for how to set these values. See the example:
+See the section in `_ricochet.toml` for how to set these values.
+See the example:
 
 ```toml
 [serve]
@@ -24,7 +26,8 @@ max_connections = 10
 
 ## Minimum instances
 
-By default, the minimum number of instances for all services is 0. This means that an instance will be started only when someone attempts to connect to the service (either via browser or http request).
+By default, the minimum number of instances for all services is 0.
+This means that an instance will be started only when someone attempts to connect to the service (either via browser or http request).
 
 To prevent a cold start, you can specify a minimum number of instances to be running at all times.
 This can be particularly useful for applications with slow start ups.

--- a/src/content/docs/v0-1/user/quickstart.mdx
+++ b/src/content/docs/v0-1/user/quickstart.mdx
@@ -5,7 +5,9 @@ tableOfContents: false
 
 import { Tabs, TabItem, Steps, Aside } from "@astrojs/starlight/components";
 
-Deploy your first app in minutes using our public trial instance at [try.ricochet.rs](https://try.ricochet.rs). Note that the trial instance is wiped weekly. Do not use it for production purposes.
+Deploy your first app in minutes using our public trial instance at [try.ricochet.rs](https://try.ricochet.rs).
+Note that the trial instance is wiped weekly.
+Do not use it for production purposes.
 
 <Steps>
 
@@ -65,7 +67,8 @@ Deploy your first app in minutes using our public trial instance at [try.ricoche
     ricochet deploy
     ```
 
-    You'll be prompted to create a `_ricochet.toml` file. This file is required for deploying to ricochet and tracks your item's configuration.
+    You'll be prompted to create a `_ricochet.toml` file.
+    This file is required for deploying to ricochet and tracks your item's configuration.
 
     Enter `yes`.
 
@@ -79,7 +82,8 @@ Deploy your first app in minutes using our public trial instance at [try.ricoche
 
 6. Select the content type
 
-    Choose **Shiny** from the content type options. You can type "sh" to filter the list.
+    Choose **Shiny** from the content type options.
+    You can type "sh" to filter the list.
 
     ```
     ? Choose content type › Shiny
@@ -87,7 +91,8 @@ Deploy your first app in minutes using our public trial instance at [try.ricoche
 
 7. Specify the entrypoint
 
-    The entrypoint is the file or folder that starts your app. For this example, select **app.R**.
+    The entrypoint is the file or folder that starts your app.
+    For this example, select **app.R**.
 
     ```
     ? Select Shiny app entrypoint › app.R
@@ -95,7 +100,8 @@ Deploy your first app in minutes using our public trial instance at [try.ricoche
 
 8. Give the item a name
 
-    Enter a display name for your app. This name appears in the ricochet UI and can contain spaces, letters, and numbers.
+    Enter a display name for your app.
+    This name appears in the ricochet UI and can contain spaces, letters, and numbers.
 
     ```
     ? Content item name › My First Shiny App

--- a/src/content/docs/v0-1/user/tasks/1-invoke.mdx
+++ b/src/content/docs/v0-1/user/tasks/1-invoke.mdx
@@ -2,9 +2,11 @@
 title: "Invoking Tasks"
 ---
 
-All tasks—e.g. R / Julia scripts, R Markdown, or Quarto documents—can be **invoked**.
+All tasks—e.g.
+R / Julia scripts, R Markdown, or Quarto documents—can be **invoked**.
 
-Invoking a task causes it to run. If the task is scheduled, you can invoke the item outside of its schedule for one-off execution.
+Invoking a task causes it to run.
+If the task is scheduled, you can invoke the item outside of its schedule for one-off execution.
 
 You can use the `{ricochet}` R package to invoke a task:
 


### PR DESCRIPTION
@JosiahParry This should allow you to write as you like and run `just fmt` at the end to make me happy 🙃 Would that work for you?

NB: before doing so I also checked out [flowmark](https://github.com/jlevy/flowmark) and [readable](https://github.com/bobheadxi/readable) but the combination of JS and markdown in one file gives both a hard time. 