### PR TITLE
docs: update hosts docs

### DIFF
--- a/src/content/docs/dev/admin/installation/1-host.mdx
+++ b/src/content/docs/dev/admin/installation/1-host.mdx
@@ -21,16 +21,16 @@ Ricochet Server packages are published to object storage.
 <Tabs>
   <TabItem label="Debian / Ubuntu">
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-server_${VERSION}-1_amd64.deb
-    sudo apt install ./ricochet-server_${VERSION}-1_amd64.deb
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-server_${VERSION#v}-1_amd64.deb
+    sudo apt install ./ricochet-server_${VERSION#v}-1_amd64.deb
     ```
   </TabItem>
   <TabItem label="RHEL / AlmaLinux">
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-server-${VERSION}-1.el10.x86_64.rpm
-    sudo dnf install ./ricochet-server-${VERSION}-1.el10.x86_64.rpm
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-server-${VERSION#v}-1.el10.x86_64.rpm
+    sudo dnf install ./ricochet-server-${VERSION#v}-1.el10.x86_64.rpm
     ```
   </TabItem>
   <TabItem label="Standalone binary">
@@ -43,15 +43,15 @@ Ricochet Server packages are published to object storage.
     </Aside>
 
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
     # For x86_64
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-${VERSION}-x86_64.tar.gz
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-${VERSION#v}-x86_64.tar.gz
 
     # Or for aarch64
-    # curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-${VERSION}-aarch64.tar.gz
+    # curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-${VERSION#v}-aarch64.tar.gz
 
     # Extract and install
-    tar -xzf ricochet-${VERSION}-*.tar.gz
+    tar -xzf ricochet-${VERSION#v}-*.tar.gz
     chmod +x ricochet
     sudo mv ricochet /usr/local/bin/
     ```

--- a/src/content/docs/v0-1/admin/installation/1-host.mdx
+++ b/src/content/docs/v0-1/admin/installation/1-host.mdx
@@ -21,16 +21,16 @@ Ricochet Server packages are published to object storage.
 <Tabs>
   <TabItem label="Debian / Ubuntu">
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-server_${VERSION}-1_amd64.deb
-    sudo apt install ./ricochet-server_${VERSION}-1_amd64.deb
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-server_${VERSION#v}-1_amd64.deb
+    sudo apt install ./ricochet-server_${VERSION#v}-1_amd64.deb
     ```
   </TabItem>
   <TabItem label="RHEL / AlmaLinux">
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-server-${VERSION}-1.el10.x86_64.rpm
-    sudo dnf install ./ricochet-server-${VERSION}-1.el10.x86_64.rpm
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-server-${VERSION#v}-1.el10.x86_64.rpm
+    sudo dnf install ./ricochet-server-${VERSION#v}-1.el10.x86_64.rpm
     ```
   </TabItem>
   <TabItem label="Standalone binary">
@@ -43,15 +43,15 @@ Ricochet Server packages are published to object storage.
     </Aside>
 
     ```sh
-    VERSION=$(curl -s https://ricochet.rs/releases.json | jq -r '.latest' | sed 's/^v//')
+    VERSION=$(curl -s https://ricochet.rs/releases.json | grep -o '"latest": *"[^"]*"' | grep -o 'v[0-9.]*')
     # For x86_64
-    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-${VERSION}-x86_64.tar.gz
+    curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-${VERSION#v}-x86_64.tar.gz
 
     # Or for aarch64
-    # curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION}/ricochet-${VERSION}-aarch64.tar.gz
+    # curl -fLO https://hel1.your-objectstorage.com/ricochet-server/${VERSION#v}/ricochet-${VERSION#v}-aarch64.tar.gz
 
     # Extract and install
-    tar -xzf ricochet-${VERSION}-*.tar.gz
+    tar -xzf ricochet-${VERSION#v}-*.tar.gz
     chmod +x ricochet
     sudo mv ricochet /usr/local/bin/
     ```


### PR DESCRIPTION
This PR modifies the `Host` installation page.

- Clarified that `uv` managed python is **required**
- Clarified that `juliaup` managed julia is **required**
- Mentioned that ricochet vendors uv and juliaup
- linked RICOCHET_HOME docs to vendored section
- Added standalone binary installation instructions
- Added VERSION to installion instructions 
- Clarified that the binary is called `ricochet` but the systemd service is `ricochet-server`
- I moved the Ansible section below the language interpreter section
