### PR TITLE
docs: add API usage examples to R, Python, and Julia deployment pages

### DIFF
--- a/src/content/docs/v0-6/user/deployment/4-r.mdx
+++ b/src/content/docs/v0-6/user/deployment/4-r.mdx
@@ -75,3 +75,80 @@ You can also install R from [CRAN](https://cran.r-project.org/) or your distribu
 
 Ricochet vendors `renv` at `$RICOCHET_HOME/vendor`.
 When a bundle is deployed, ricochet restores R package dependencies from the `renv.lock` file using the vendored `renv`.
+
+## Using the API
+
+You can deploy and manage R content programmatically using the ricochet REST API.
+The examples below use [`{httr2}`](https://httr2.r-lib.org/).
+API keys are created in the ricochet UI under **Credentials → API Keys**.
+
+### Deploy a bundle
+
+Bundle your project as a `.tar.gz` archive and upload it with the `_ricochet.toml` config.
+
+```r
+library(httr2)
+
+server <- "https://try.ricochet.rs"
+api_key <- Sys.getenv("RICOCHET_API_KEY")
+
+# Create a tar.gz bundle of the project directory
+bundle_path <- tempfile(fileext = ".tar.gz")
+tar(bundle_path, files = ".", compression = "gzip")
+
+# Deploy new content
+resp <- request(server) |>
+  req_url_path_append("api", "v0", "content", "upload") |>
+  req_headers(Authorization = paste("Key", api_key)) |>
+  req_body_multipart(
+    bundle = curl::form_file(bundle_path, type = "application/gzip"),
+    config = curl::form_file("_ricochet.toml", type = "application/toml")
+  ) |>
+  req_perform()
+
+result <- resp_body_json(resp)
+result$id
+#> "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+```
+
+To redeploy existing content, pass `id` instead of `config`:
+
+```r
+resp <- request(server) |>
+  req_url_path_append("api", "v0", "content", "upload") |>
+  req_headers(Authorization = paste("Key", api_key)) |>
+  req_body_multipart(
+    bundle = curl::form_file(bundle_path, type = "application/gzip"),
+    id = "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+  ) |>
+  req_perform()
+```
+
+### Invoke a task
+
+```r
+content_id <- "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+
+resp <- request(server) |>
+  req_url_path_append("api", "v0", "content", content_id, "invoke") |>
+  req_headers(Authorization = paste("Key", api_key)) |>
+  req_body_json(list(params = list(n = 100))) |>
+  req_perform()
+
+resp_body_json(resp)
+```
+
+### List your content
+
+```r
+resp <- request(server) |>
+  req_url_path_append("api", "v0", "user", "items") |>
+  req_headers(Authorization = paste("Key", api_key)) |>
+  req_perform()
+
+items <- resp_body_json(resp)
+```
+
+<Aside type="tip">
+  See the full [API reference](https://try.ricochet.rs/api/docs) for all available endpoints.
+</Aside>

--- a/src/content/docs/v0-6/user/deployment/5-julia.mdx
+++ b/src/content/docs/v0-6/user/deployment/5-julia.mdx
@@ -67,3 +67,73 @@ When a deployment is received, ricochet uses `juliaup` to discover installed Jul
 ### Environment restoration
 
 When a bundle is deployed, ricochet restores Julia package dependencies from the `Manifest.toml` file using Julia's built-in package manager.
+
+## Using the API
+
+You can deploy and manage Julia content programmatically using the ricochet REST API.
+The examples below use [`HTTP.jl`](https://juliaweb.github.io/HTTP.jl/).
+API keys are created in the ricochet UI under **Credentials → API Keys**.
+
+### Deploy a bundle
+
+Bundle your project as a `.tar.gz` archive and upload it with the `_ricochet.toml` config.
+
+```julia
+using HTTP, JSON3, Tar, CodecZlib
+
+server = "https://try.ricochet.rs"
+api_key = ENV["RICOCHET_API_KEY"]
+headers = ["Authorization" => "Key $api_key"]
+
+# Create a tar.gz bundle of the project directory
+bundle_path = tempname() * ".tar.gz"
+open(bundle_path, "w") do io
+    gz = GzipCompressorStream(io)
+    Tar.create(".", gz)
+    close(gz)
+end
+
+# Deploy new content
+body = HTTP.Form(Dict(
+    "bundle" => HTTP.Multipart("bundle.tar.gz", open(bundle_path), "application/gzip"),
+    "config" => HTTP.Multipart("_ricochet.toml", open("_ricochet.toml"), "application/toml"),
+))
+resp = HTTP.post("$server/api/v0/content/upload", headers, body)
+result = JSON3.read(resp.body)
+result.id
+#> "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+```
+
+To redeploy existing content, pass `id` instead of `config`:
+
+```julia
+body = HTTP.Form(Dict(
+    "bundle" => HTTP.Multipart("bundle.tar.gz", open(bundle_path), "application/gzip"),
+    "id" => "01JSZAXZ3TSTAYXP56ARDVFJCJ",
+))
+resp = HTTP.post("$server/api/v0/content/upload", headers, body)
+```
+
+### Invoke a task
+
+```julia
+content_id = "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+
+resp = HTTP.post(
+    "$server/api/v0/content/$content_id/invoke",
+    ["Authorization" => "Key $api_key", "Content-Type" => "application/json"],
+    JSON3.write(Dict("params" => Dict("n" => 100))),
+)
+JSON3.read(resp.body)
+```
+
+### List your content
+
+```julia
+resp = HTTP.get("$server/api/v0/user/items", headers)
+items = JSON3.read(resp.body)
+```
+
+<Aside type="tip">
+  See the full [API reference](https://try.ricochet.rs/api/docs) for all available endpoints.
+</Aside>

--- a/src/content/docs/v0-6/user/deployment/6-python.mdx
+++ b/src/content/docs/v0-6/user/deployment/6-python.mdx
@@ -98,3 +98,80 @@ The `--no-python-downloads` flag prevents `uv` from downloading Python versions 
 Resolved packages are cached at `$RICOCHET_HOME/.cache/uv`.
 This directory is created automatically during the first Python deployment.
 The cache is shared across all Python content items on the server.
+
+## Using the API
+
+You can deploy and manage Python content programmatically using the ricochet REST API.
+The examples below use [`requests`](https://requests.readthedocs.io/).
+API keys are created in the ricochet UI under **Credentials → API Keys**.
+
+### Deploy a bundle
+
+Bundle your project as a `.tar.gz` archive and upload it with the `_ricochet.toml` config.
+
+```python
+import os
+import tarfile
+import tempfile
+import requests
+
+server = "https://try.ricochet.rs"
+api_key = os.environ["RICOCHET_API_KEY"]
+headers = {"Authorization": f"Key {api_key}"}
+
+# Create a tar.gz bundle of the project directory
+bundle_path = tempfile.mktemp(suffix=".tar.gz")
+with tarfile.open(bundle_path, "w:gz") as tar:
+    tar.add(".", arcname=".")
+
+# Deploy new content
+resp = requests.post(
+    f"{server}/api/v0/content/upload",
+    headers=headers,
+    files={
+        "bundle": ("bundle.tar.gz", open(bundle_path, "rb"), "application/gzip"),
+        "config": ("_ricochet.toml", open("_ricochet.toml", "rb"), "application/toml"),
+    },
+)
+result = resp.json()
+result["id"]
+#> "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+```
+
+To redeploy existing content, pass `id` instead of `config`:
+
+```python
+resp = requests.post(
+    f"{server}/api/v0/content/upload",
+    headers=headers,
+    files={"bundle": ("bundle.tar.gz", open(bundle_path, "rb"), "application/gzip")},
+    data={"id": "01JSZAXZ3TSTAYXP56ARDVFJCJ"},
+)
+```
+
+### Invoke a task
+
+```python
+content_id = "01JSZAXZ3TSTAYXP56ARDVFJCJ"
+
+resp = requests.post(
+    f"{server}/api/v0/content/{content_id}/invoke",
+    headers=headers,
+    json={"params": {"n": 100}},
+)
+resp.json()
+```
+
+### List your content
+
+```python
+resp = requests.get(
+    f"{server}/api/v0/user/items",
+    headers=headers,
+)
+items = resp.json()
+```
+
+<Aside type="tip">
+  See the full [API reference](https://try.ricochet.rs/api/docs) for all available endpoints.
+</Aside>


### PR DESCRIPTION
## Summary

- Adds a "Using the API" section to the R, Python, and Julia deployment pages (`4-r.mdx`, `5-julia.mdx`, `6-python.mdx`)
- Each section shows idiomatic code examples for deploying a bundle, invoking a task, and listing content via the REST API
- R uses httr2, Python uses requests, Julia uses HTTP.jl