### PR TITLE
fix: append trailing slashes to internal links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ import starlightVersions from "starlight-versions";
 import { latestVersionRedirectsIntegration } from "./scripts/latest-version-redirects.mjs";
 import rehypeMermaid from "rehype-mermaid";
 import rehypeFigure from "rehype-figure";
+import rehypeTrailingSlash from "./scripts/rehype-trailing-slash.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -182,7 +183,11 @@ export default defineConfig({
     // Astro 6.4.2 regressed the default for `gfm` from true to false;
     // see https://github.com/withastro/astro/issues/16971
     gfm: true,
-    rehypePlugins: [[rehypeMermaid, { strategy: "pre-mermaid" }], rehypeFigure],
+    rehypePlugins: [
+      [rehypeMermaid, { strategy: "pre-mermaid" }],
+      rehypeFigure,
+      rehypeTrailingSlash,
+    ],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/scripts/rehype-trailing-slash.mjs
+++ b/scripts/rehype-trailing-slash.mjs
@@ -1,0 +1,36 @@
+import { visit } from "unist-util-visit";
+
+// The static host serves pages only at their trailing-slash URL
+// (e.g. `/foo/bar/`) and 404s the bare path. Astro renders authored
+// markdown links verbatim, so internal links written without a trailing
+// slash break in production. This plugin appends the slash at build time.
+export default function rehypeTrailingSlash() {
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      if (node.tagName !== "a") return;
+      const href = node.properties?.href;
+      if (typeof href !== "string" || href.length === 0) return;
+
+      // Skip external links, protocol-relative URLs, and special schemes.
+      if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("//")) return;
+      // Skip pure fragments.
+      if (href.startsWith("#")) return;
+
+      const hashIndex = href.indexOf("#");
+      const queryIndex = href.indexOf("?");
+      let cut = href.length;
+      if (hashIndex !== -1) cut = Math.min(cut, hashIndex);
+      if (queryIndex !== -1) cut = Math.min(cut, queryIndex);
+
+      const path = href.slice(0, cut);
+      const suffix = href.slice(cut);
+      if (path.length === 0 || path.endsWith("/")) return;
+
+      // Skip links to files (last segment has an extension).
+      const lastSegment = path.slice(path.lastIndexOf("/") + 1);
+      if (lastSegment.includes(".")) return;
+
+      node.properties.href = `${path}/${suffix}`;
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Hand-authored internal links 404 in production. The static host serves pages only at their trailing-slash URL (e.g. `/dev/user/deployment/1-ricochet-cli/` → 200) and 404s the bare path (`/dev/user/deployment/1-ricochet-cli`). Under `trailingSlash: "ignore"`, Astro renders markdown link hrefs verbatim, so any internal link written without a trailing slash breaks once deployed. (`trailingSlash: "always"` does not help — Astro still does not rewrite authored hrefs.)

This adds a build-time rehype plugin (`scripts/rehype-trailing-slash.mjs`) that appends a trailing slash to internal page links. It is a single-point fix covering every hand-authored internal link across all versions.

The plugin:
- skips external URLs, `mailto:`/other schemes, protocol-relative URLs, and pure anchors
- skips file links (last path segment has an extension), leaving assets like `.png`/`.css`/`.svg`/`.webmanifest` untouched
- preserves `?query` strings and `#fragment` (e.g. `/dev/user/deployment/2-ricochet-toml/#serve-settings`)
- is idempotent (skips links already ending in `/`)

## Why the link checkers missed this

- `starlight-links-validator` resolves links to page slugs (trailing-slash-insensitive) → reports valid
- pre-deploy lychee checks the `dist/` filesystem, where bare paths resolve to the directory's `index.html` → valid
- post-deploy lychee is pointed at a single homepage URL and does not recursively crawl deep content pages

The plugin is what keeps these links correct going forward.