### PR TITLE
feat(release): script docs version creation and prune old versions

### DIFF
--- a/scripts/release-docs-version.mjs
+++ b/scripts/release-docs-version.mjs
@@ -1,0 +1,212 @@
+// Create (or patch) a docs version during a release, then prune old versions.
+//
+// Encapsulates the docs-mutation logic the release workflow used to inline as
+// shell+sed. The workflow is still responsible for cloning the repo, running
+// prettier, and committing/pushing — this script only edits files on disk.
+//
+// Usage: node scripts/release-docs-version.mjs <tag>
+//   <tag> defaults to $CI_COMMIT_TAG (e.g. "v1.2.3" or "1.2.3-beta.1").
+
+import {
+  cpSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+// How many `v<major>-<minor>` versions to keep. Older ones are pruned during
+// release. The `dev` version is never counted or pruned.
+export const KEEP_MINOR_VERSIONS = 5;
+
+const VERSION_REGEX = /^v(\d+)-(\d+)$/;
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function parseTag(tag) {
+  const stripped = tag.replace(/^v/, "");
+  const base = stripped.replace(/(-.*|\+.*)$/, "");
+  const [major, minor] = base.split(".");
+  if (major === undefined || minor === undefined) {
+    throw new Error(`Cannot parse major.minor from tag "${tag}"`);
+  }
+  return {
+    slug: `v${major}-${minor}`,
+    label: `${major}.${minor}`,
+    major: parseInt(major, 10),
+    minor: parseInt(minor, 10),
+  };
+}
+
+export function listVersions(names) {
+  const versions = [];
+  for (const name of names) {
+    const m = name.match(VERSION_REGEX);
+    if (!m) continue;
+    versions.push({
+      slug: name,
+      major: parseInt(m[1], 10),
+      minor: parseInt(m[2], 10),
+    });
+  }
+  versions.sort((a, b) => b.major - a.major || b.minor - a.minor);
+  return versions;
+}
+
+// Slugs to remove: everything beyond the newest `keep` minor versions. `dev`
+// and any non-versioned directory are ignored, so they are never returned.
+export function versionsToPrune(names, keep = KEEP_MINOR_VERSIONS) {
+  return listVersions(names)
+    .slice(keep)
+    .map((v) => v.slug);
+}
+
+export function setCurrentLabel(src, label) {
+  return src.replace(
+    /(current:\s*\{\s*label:\s*")[0-9]+\.[0-9]+(\s*\(latest\)")/,
+    `$1${label}$2`,
+  );
+}
+
+export function prependVersionEntry(src, slug, label) {
+  if (new RegExp(`slug:\\s*"${escapeRe(slug)}"`).test(src)) return src;
+  const entry = `{ slug: "${slug}", label: "${label}" }`;
+  if (/versions:\s*\[\s*\]/.test(src)) {
+    return src.replace(/versions:\s*\[\s*\]/, `versions: [${entry}]`);
+  }
+  return src.replace(/(versions:\s*\[)/, `$1${entry}, `);
+}
+
+export function removeVersionEntries(src, slugs) {
+  let out = src;
+  for (const slug of slugs) {
+    const re = new RegExp(
+      `\\s*\\{\\s*slug:\\s*"${escapeRe(slug)}",\\s*label:\\s*"[^"]*"\\s*\\},?`,
+      "g",
+    );
+    out = out.replace(re, "");
+  }
+  return out;
+}
+
+export function addLycheeExclude(src, slug) {
+  const pattern = `https://docs.ricochet.rs/${slug}/.*`;
+  if (src.includes(pattern)) return src;
+  return src.replace(/^\]$/m, `    "${pattern}",\n]`);
+}
+
+export function removeLycheeExcludes(src, slugs) {
+  let out = src;
+  for (const slug of slugs) {
+    const re = new RegExp(
+      `^.*https://docs\\.ricochet\\.rs/${escapeRe(slug)}/.*$\\n?`,
+      "m",
+    );
+    out = out.replace(re, "");
+  }
+  return out;
+}
+
+export function updateRootRedirect(src, slug) {
+  return src
+    .replace(/url=\/v[0-9]+-[0-9]+\//g, `url=/${slug}/`)
+    .replace(/\/v[0-9]+-[0-9]+\//g, `/${slug}/`);
+}
+
+export function updateVersionIndex(src, slug) {
+  return src
+    .replace(/slug:\s*"(?:dev|v[0-9]+-[0-9]+)"/, `slug: "${slug}"`)
+    .replace(/\/(?:dev|v[0-9]+-[0-9]+)\//g, `/${slug}/`);
+}
+
+function readCurrentLabel(src) {
+  const m = src.match(/current:\s*\{\s*label:\s*"([0-9]+\.[0-9]+)/);
+  return m ? m[1] : null;
+}
+
+// Edit a file in place via a (string) -> string transform.
+function edit(path, fn) {
+  if (!existsSync(path)) return;
+  writeFileSync(path, fn(readFileSync(path, "utf8")));
+}
+
+export function pruneVersions(root, slugs) {
+  if (slugs.length === 0) return;
+  const docsDir = join(root, "src/content/docs");
+  const versionsDir = join(root, "src/content/versions");
+  for (const slug of slugs) {
+    rmSync(join(docsDir, slug), { recursive: true, force: true });
+    rmSync(join(versionsDir, `${slug}.json`), { force: true });
+  }
+  edit(join(root, "astro.config.mjs"), (s) => removeVersionEntries(s, slugs));
+  edit(join(root, "lychee.toml"), (s) => removeLycheeExcludes(s, slugs));
+}
+
+export function releaseDocsVersion(
+  root,
+  tag,
+  { keep = KEEP_MINOR_VERSIONS } = {},
+) {
+  const { slug, label } = parseTag(tag);
+  const docsDir = join(root, "src/content/docs");
+  const versionsDir = join(root, "src/content/versions");
+  const versionConfig = join(versionsDir, `${slug}.json`);
+  const versionDir = join(docsDir, slug);
+
+  if (existsSync(versionConfig) || existsSync(versionDir)) {
+    console.log(
+      `Version ${slug} already exists — patch release, no docs changes.`,
+    );
+    return { created: false, slug, label, pruned: [] };
+  }
+
+  console.log(`Creating new docs version ${slug} from dev...`);
+  cpSync(join(versionsDir, "dev.json"), versionConfig);
+  cpSync(join(docsDir, "dev"), versionDir, { recursive: true });
+
+  edit(join(root, "astro.config.mjs"), (src) => {
+    let out = src;
+    const oldLabel = readCurrentLabel(out);
+    if (oldLabel) {
+      const oldSlug = `v${oldLabel.replace(".", "-")}`;
+      out = prependVersionEntry(out, oldSlug, oldLabel);
+    }
+    out = setCurrentLabel(out, label);
+    out = prependVersionEntry(out, slug, label);
+    return out;
+  });
+
+  edit(join(docsDir, "index.mdx"), (s) => updateRootRedirect(s, slug));
+  edit(join(versionDir, "index.mdx"), (s) => updateVersionIndex(s, slug));
+  edit(join(root, "lychee.toml"), (s) => addLycheeExclude(s, slug));
+
+  const pruned = versionsToPrune(readdirSync(docsDir), keep);
+  if (pruned.length) {
+    console.log(
+      `Pruning old versions (keeping newest ${keep}): ${pruned.join(", ")}`,
+    );
+    pruneVersions(root, pruned);
+  }
+
+  return { created: true, slug, label, pruned };
+}
+
+function main() {
+  const tag = process.argv[2] ?? process.env.CI_COMMIT_TAG;
+  if (!tag) {
+    console.error(
+      "Usage: node scripts/release-docs-version.mjs <tag> (or set CI_COMMIT_TAG)",
+    );
+    process.exit(1);
+  }
+  releaseDocsVersion(process.cwd(), tag);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/release-docs-version.test.mjs
+++ b/scripts/release-docs-version.test.mjs
@@ -1,0 +1,231 @@
+import { test, expect } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseTag,
+  listVersions,
+  versionsToPrune,
+  setCurrentLabel,
+  prependVersionEntry,
+  removeVersionEntries,
+  addLycheeExclude,
+  removeLycheeExcludes,
+  updateRootRedirect,
+  updateVersionIndex,
+  releaseDocsVersion,
+} from "./release-docs-version.mjs";
+
+test("parseTag handles plain, v-prefixed and pre-release tags", () => {
+  expect(parseTag("v1.2.3")).toMatchObject({ slug: "v1-2", label: "1.2" });
+  expect(parseTag("0.10.0")).toMatchObject({ slug: "v0-10", label: "0.10" });
+  expect(parseTag("1.2.3-beta.1")).toMatchObject({
+    slug: "v1-2",
+    label: "1.2",
+  });
+  expect(parseTag("2.0.0+build.5")).toMatchObject({
+    slug: "v2-0",
+    label: "2.0",
+  });
+});
+
+test("listVersions sorts descending and ignores non-version names", () => {
+  const v = listVersions(["v0-2", "dev", "v0-10", "releases", "v0-9"]);
+  expect(v.map((x) => x.slug)).toEqual(["v0-10", "v0-9", "v0-2"]);
+});
+
+test("versionsToPrune keeps newest N and never returns dev", () => {
+  const names = [
+    "dev",
+    "v0-1",
+    "v0-2",
+    "v0-6",
+    "v0-7",
+    "v0-8",
+    "v0-9",
+    "v0-10",
+  ];
+  expect(versionsToPrune(names, 5)).toEqual(["v0-2", "v0-1"]);
+  expect(versionsToPrune(["dev", "v0-1", "v0-2"], 5)).toEqual([]);
+});
+
+test("setCurrentLabel swaps only the current label", () => {
+  const src = `current: { label: "0.9 (latest)", redirect: "root" }`;
+  expect(setCurrentLabel(src, "0.10")).toBe(
+    `current: { label: "0.10 (latest)", redirect: "root" }`,
+  );
+});
+
+test("prependVersionEntry adds, fills empty array, and is idempotent", () => {
+  expect(
+    prependVersionEntry(
+      `versions: [{ slug: "v0-9", label: "0.9" }]`,
+      "v0-10",
+      "0.10",
+    ),
+  ).toBe(
+    `versions: [{ slug: "v0-10", label: "0.10" }, { slug: "v0-9", label: "0.9" }]`,
+  );
+  expect(prependVersionEntry(`versions: []`, "v0-10", "0.10")).toBe(
+    `versions: [{ slug: "v0-10", label: "0.10" }]`,
+  );
+  const existing = `versions: [{ slug: "v0-10", label: "0.10" }]`;
+  expect(prependVersionEntry(existing, "v0-10", "0.10")).toBe(existing);
+});
+
+test("removeVersionEntries drops matching entries, multiline-safe", () => {
+  const src = [
+    "versions: [",
+    '  { slug: "v0-10", label: "0.10" },',
+    '  { slug: "v0-2", label: "0.2" },',
+    '  { slug: "dev", label: "dev" },',
+    '  { slug: "v0-1", label: "0.1" },',
+    "],",
+  ].join("\n");
+  const out = removeVersionEntries(src, ["v0-1", "v0-2"]);
+  expect(out).not.toContain('slug: "v0-1"');
+  expect(out).not.toContain('slug: "v0-2"');
+  expect(out).toContain('slug: "v0-10"');
+  expect(out).toContain('slug: "dev"');
+});
+
+test("lychee exclude add is idempotent and remove is targeted", () => {
+  const base = [
+    "exclude = [",
+    '    "https://docs.ricochet.rs/v0-9/.*",',
+    "]",
+  ].join("\n");
+  const added = addLycheeExclude(base, "v0-10");
+  expect(added).toContain('"https://docs.ricochet.rs/v0-10/.*"');
+  expect(addLycheeExclude(added, "v0-10")).toBe(added);
+  const removed = removeLycheeExcludes(added, ["v0-9"]);
+  expect(removed).not.toContain("v0-9");
+  expect(removed).toContain("v0-10");
+});
+
+test("updateRootRedirect rewrites both the meta refresh and the link", () => {
+  const src = 'content: "0; url=/v0-9/"\nRedirecting to [docs](/v0-9/)...';
+  const out = updateRootRedirect(src, "v0-10");
+  expect(out).toBe(
+    'content: "0; url=/v0-10/"\nRedirecting to [docs](/v0-10/)...',
+  );
+});
+
+test("updateVersionIndex rewrites slug and paths copied from dev", () => {
+  const src = 'slug: "dev"\nsee [x](/dev/user/quickstart/)';
+  expect(updateVersionIndex(src, "v0-10")).toBe(
+    'slug: "v0-10"\nsee [x](/v0-10/user/quickstart/)',
+  );
+});
+
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), "rel-"));
+  const docs = join(root, "src/content/docs");
+  const versions = join(root, "src/content/versions");
+  mkdirSync(join(docs, "dev"), { recursive: true });
+  mkdirSync(versions, { recursive: true });
+  writeFileSync(join(versions, "dev.json"), '{ "sidebar": [] }\n');
+  writeFileSync(join(docs, "dev", "index.mdx"), 'slug: "dev"\nlink /dev/x/\n');
+  for (let minor = 1; minor <= 9; minor++) {
+    const slug = `v0-${minor}`;
+    mkdirSync(join(docs, slug), { recursive: true });
+    writeFileSync(join(docs, slug, "index.mdx"), `slug: "${slug}"\n`);
+    writeFileSync(join(versions, `${slug}.json`), '{ "sidebar": [] }\n');
+  }
+  writeFileSync(
+    join(docs, "index.mdx"),
+    'content: "0; url=/v0-9/"\n[docs](/v0-9/)\n',
+  );
+  const versionsLine = Array.from(
+    { length: 9 },
+    (_, i) => `{ slug: "v0-${9 - i}", label: "0.${9 - i}" }`,
+  ).join(", ");
+  writeFileSync(
+    join(root, "astro.config.mjs"),
+    `current: { label: "0.9 (latest)", redirect: "root" },\nversions: [${versionsLine}, { slug: "dev", label: "dev" }],\n`,
+  );
+  writeFileSync(
+    join(root, "lychee.toml"),
+    "exclude = [\n" +
+      Array.from(
+        { length: 9 },
+        (_, i) => `    "https://docs.ricochet.rs/v0-${i + 1}/.*",`,
+      ).join("\n") +
+      "\n]\n",
+  );
+  return {
+    root,
+    docs,
+    versions,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test("releaseDocsVersion creates v0-10 and prunes down to newest 5 + dev", () => {
+  const { root, docs, versions, cleanup } = makeRepo();
+  try {
+    const result = releaseDocsVersion(root, "v0.10.0");
+    expect(result.created).toBe(true);
+    expect(result.slug).toBe("v0-10");
+    expect(result.pruned.sort()).toEqual([
+      "v0-1",
+      "v0-2",
+      "v0-3",
+      "v0-4",
+      "v0-5",
+    ]);
+
+    // New version exists and was rewritten from dev.
+    expect(existsSync(join(docs, "v0-10", "index.mdx"))).toBe(true);
+    expect(readFileSync(join(docs, "v0-10", "index.mdx"), "utf8")).toContain(
+      'slug: "v0-10"',
+    );
+    expect(existsSync(join(versions, "v0-10.json"))).toBe(true);
+
+    // Kept: v0-6..v0-10 + dev. Pruned: v0-1..v0-5.
+    for (const minor of [6, 7, 8, 9, 10]) {
+      expect(existsSync(join(docs, `v0-${minor}`))).toBe(true);
+    }
+    for (const minor of [1, 2, 3, 4, 5]) {
+      expect(existsSync(join(docs, `v0-${minor}`))).toBe(false);
+      expect(existsSync(join(versions, `v0-${minor}.json`))).toBe(false);
+    }
+    expect(existsSync(join(docs, "dev"))).toBe(true);
+
+    const astro = readFileSync(join(root, "astro.config.mjs"), "utf8");
+    expect(astro).toContain('current: { label: "0.10 (latest)"');
+    expect(astro).toContain('slug: "v0-10"');
+    expect(astro).toContain('slug: "dev"');
+    expect(astro).not.toContain('slug: "v0-1"');
+    expect(astro).not.toContain('slug: "v0-5"');
+
+    const lychee = readFileSync(join(root, "lychee.toml"), "utf8");
+    expect(lychee).toContain("v0-10");
+    expect(lychee).not.toContain("v0-1/");
+    expect(lychee).not.toContain("v0-5/");
+
+    expect(readFileSync(join(docs, "index.mdx"), "utf8")).toContain(
+      "url=/v0-10/",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("releaseDocsVersion is a no-op on patch releases", () => {
+  const { root, cleanup } = makeRepo();
+  try {
+    const result = releaseDocsVersion(root, "v0.9.7");
+    expect(result.created).toBe(false);
+    expect(result.pruned).toEqual([]);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/release-docs-version.mjs`, encapsulating the docs-version creation logic that the `ricochet` release workflow previously inlined as shell+sed (`.crow/release.yaml` lines 111–250).
- Enhances it to prune old versions: only the newest 5 minor versions (`v<major>-<minor>`) are kept; older ones are deleted from the docs dir, `src/content/versions/*.json`, the `astro.config.mjs` versions array, and the `lychee.toml` exclude list. The `dev` version is never counted or pruned.
- Adds `scripts/release-docs-version.test.mjs` (`bun:test`) covering tag parsing, prune selection, each string transform, and a full create-and-prune integration run.

The script only edits files on disk; cloning, prettier, and commit/push remain the workflow's responsibility. Patch releases (existing minor version) are a no-op.

## Follow-ups (not in this PR)

- The release workflow in the `ricochet` repo still needs to be updated to call this script in place of the inline block.
- Existing versions (v0-1…v0-10) are untouched; pruning takes effect on the next release.