### PR TITLE
docs(auth): document User.Read.All grant for Entra avatar sync

### DIFF
--- a/src/content/docs/dev/admin/configuration/1-authentication.mdx
+++ b/src/content/docs/dev/admin/configuration/1-authentication.mdx
@@ -91,6 +91,17 @@ Pick *Group ID* (the default) or *sAMAccountName* depending on what your tenant 
   Without it, ricochet can still sync group memberships at login from the ID token but cannot pull display names from the Graph API.
 </Aside>
 
+### User avatars
+
+Standard OIDC providers populate user avatars from the `picture` claim, but Entra omits that claim and serves photos only from Microsoft Graph.
+When `provider = "entra"` is set, ricochet fetches each user's photo at login from `GET /users/{id}/photo/$value`, resizes it to a 128×128 PNG, and stores it without overwriting a user-uploaded avatar.
+
+<Aside type="note">
+  Fetching avatars requires the app registration to have the **`User.Read.All`** Microsoft Graph application permission granted by an administrator (admin consent).
+  The group permissions above do not cover `/users/{id}/photo`.
+  Avatar fetching is best-effort — a missing permission, missing photo, or missing `oid` claim never blocks login.
+</Aside>
+
 <Aside type="note">
   Entra applies a "group overage" limit at roughly 200 group memberships per user.
   Beyond that point Entra stops embedding the groups array in the token and references it via Microsoft Graph instead, which ricochet does not currently follow.


### PR DESCRIPTION
## Summary

Documents the new operator requirement from ricochet-rs/ricochet#1048, which syncs user avatars from Microsoft Entra via the Graph API.

- Adds a **User avatars** subsection to the Entra section of the dev authentication docs, explaining why Entra needs a Graph photo fetch (no `picture` claim).
- Notes that avatar sync requires the **`User.Read.All`** Graph application permission with admin consent, that the existing group permissions do not cover `/users/{id}/photo`, and that the fetch is best-effort and never blocks login.

Scoped to `dev` only since the feature is unreleased (not yet in v0-10).