### PR TITLE
ci: add pre-push hook running just fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,14 @@ repos:
     rev: v3.8.4
     hooks:
       - id: prettier
+
+  - repo: local
+    hooks:
+      - id: just-fmt
+        name: just fmt
+        entry: just fmt
+        language: system
+        stages:
+          - pre-push
+        pass_filenames: false
+        always_run: true

--- a/justfile
+++ b/justfile
@@ -24,6 +24,6 @@ lint: install
     bun prettier --check .
 
 # fix lints using prettier and format prose (semantic line breaks)
-fmt:
+fmt: install
     bun run scripts/semantic-breaks.mjs
     bun prettier --write .


### PR DESCRIPTION
Adds a pre-push git hook that runs `just fmt` before each push, wired through the existing `prek`/pre-commit setup.

## Changes

- **`.pre-commit-config.yaml`** — new `local` hook `just-fmt` scoped to the `pre-push` stage (`pass_filenames: false`, `always_run: true`).
- **`justfile`** — `fmt` now depends on `install` so a push from a fresh checkout installs deps before formatting.

## Setup for other contributors

The git hook itself isn't shared via the repo. After pulling, run once locally:

```sh
prek install --hook-type pre-push
```