### PR TITLE
feat: max bundle size

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,3 +27,7 @@ lint: install
 fmt: install
     bun run scripts/semantic-breaks.mjs
     bun prettier --write .
+
+
+pr-review pr_num:
+    gh pr-review review view -R ricochet-rs/docs --pr {{ pr_num }} | jq

--- a/src/content/docs/dev/admin/configuration/deployment-retention.mdx
+++ b/src/content/docs/dev/admin/configuration/deployment-retention.mdx
@@ -1,0 +1,59 @@
+---
+title: Deployment Retention
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Every time content is deployed to ricochet, the source code and dependencies are packaged together into a **bundle**.
+Bundles persist across deployments so ricochet can roll back, redeploy, or inspect past versions.
+
+## How cleanup works
+
+ricochet runs a cleanup process once daily at **05:00 UTC**.
+It evaluates every content item against the configured retention policy and deletes bundles that exceed the defined limits.
+
+<Aside type="note">
+The latest successful deployment is always protected—it will never be deleted regardless of policy.
+Pending deployments are also excluded from cleanup.
+</Aside>
+
+If no retention settings are configured, bundles accumulate without limit.
+
+## Configuration Options
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `max_deployments` | Maximum number of bundles to keep per content item | `20` |
+| `max_age_days` | Delete bundles older than this many days | No limit |
+| `max_bundle_size` | Maximum size of a bundle accepted by the `/upload` endpoint | `"100mb"` |
+
+`max_deployments` and `max_age_days` can also be overridden per content item.
+
+<Aside type="note">
+`max_bundle_size` is only respected in `ricochet-config.toml`—it cannot be set per content item.
+</Aside>
+
+Set server-wide defaults for all content items in the `[retention]` section of `ricochet-config.toml`:
+
+```toml title="ricochet-config.toml"
+[retention]
+max_deployments = 20
+max_age_days = 90
+max_bundle_size = "100mb"
+```
+
+`max_deployments` and `max_age_days` govern cleanup of existing bundles.
+`max_bundle_size` limits the size of a bundle that is accepted by the `/upload` API endpoint.
+If a bundle is larger than `max_bundle_size` it is rejected by the API.
+
+## Policy resolution
+
+Retention settings can be configured at two levels:
+
+1. **Server-wide**: in `ricochet-config.toml`, under the `[retention]` section. Applies to all content items.
+2. **Per-content**: in the content item's `_ricochet.toml`, under the `[retention]` section. Overrides the server default for that item.
+
+When both are configured, ricochet applies the **stricter** of the two values.
+A per-content policy can tighten the server default but cannot relax it.
+
+See [Deployment Retention](/dev/user/managing-content/3-retention-policy/) in the user guide for per-content configuration.

--- a/src/content/docs/dev/admin/configuration/deployment-retention.mdx
+++ b/src/content/docs/dev/admin/configuration/deployment-retention.mdx
@@ -13,7 +13,8 @@ ricochet runs a cleanup process once daily at **05:00 UTC**.
 It evaluates every content item against the configured retention policy and deletes bundles that exceed the defined limits.
 
 <Aside type="note">
-The latest successful deployment is always protected—it will never be deleted regardless of policy.
+The latest successful deployment is always protected.
+It will never be deleted regardless of policy.
 Pending deployments are also excluded from cleanup.
 </Aside>
 
@@ -30,7 +31,7 @@ If no retention settings are configured, bundles accumulate without limit.
 `max_deployments` and `max_age_days` can also be overridden per content item.
 
 <Aside type="note">
-`max_bundle_size` is only respected in `ricochet-config.toml`—it cannot be set per content item.
+`max_bundle_size` is only respected in `ricochet-config.toml`. It cannot be set per content item.
 </Aside>
 
 Set server-wide defaults for all content items in the `[retention]` section of `ricochet-config.toml`:
@@ -53,7 +54,9 @@ Retention settings can be configured at two levels:
 1. **Server-wide**: in `ricochet-config.toml`, under the `[retention]` section. Applies to all content items.
 2. **Per-content**: in the content item's `_ricochet.toml`, under the `[retention]` section. Overrides the server default for that item.
 
+<Aside type="note">
 When both are configured, ricochet applies the **stricter** of the two values.
 A per-content policy can tighten the server default but cannot relax it.
+</Aside>
 
 See [Deployment Retention](/dev/user/managing-content/3-retention-policy/) in the user guide for per-content configuration.

--- a/src/content/docs/dev/user/managing-content/3-retention-policy.mdx
+++ b/src/content/docs/dev/user/managing-content/3-retention-policy.mdx
@@ -2,7 +2,7 @@
 title: Deployment Retention
 ---
 
-import { LinkCard } from "@astrojs/starlight/components";
+import { Aside, LinkCard } from "@astrojs/starlight/components";
 
 Retention policies control how many bundles are kept for a content item and for how long.
 You can override the server-wide defaults for an individual content item in its `_ricochet.toml`.
@@ -25,5 +25,7 @@ max_deployments = 5
 max_age_days = 30
 ```
 
+<Aside type="note">
 When both a server-wide and a per-content policy are configured, ricochet applies the **stricter** of the two values.
 A per-content policy can tighten the server default but cannot relax it.
+</Aside>

--- a/src/content/docs/dev/user/managing-content/3-retention-policy.mdx
+++ b/src/content/docs/dev/user/managing-content/3-retention-policy.mdx
@@ -2,55 +2,20 @@
 title: Deployment Retention
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { LinkCard } from "@astrojs/starlight/components";
 
-Every time you deploy content to ricochet, the source code and dependencies are packaged together into a **bundle**.
-Bundles persist across deployments so ricochet can roll back, redeploy, or inspect past versions.
+Retention policies control how many bundles are kept for a content item and for how long.
+You can override the server-wide defaults for an individual content item in its `_ricochet.toml`.
 
-Over time, accumulated bundles consume disk space.
-Retention policies let you control how many bundles are kept and for how long.
+Refer to the [Deployment Retention](/dev/admin/configuration/deployment-retention/) docs in the admin guide for guidance on how retention works, cleanup behavior, and server-wide configuration.
 
-## How retention works
+<LinkCard
+  title="Deployment Retention"
+  href="/dev/admin/configuration/deployment-retention/"
+  description="How retention works, cleanup behavior, and server-wide configuration."
+/>
 
-ricochet runs a cleanup process once daily at **05:00 UTC**.
-It evaluates every content item against the configured retention policy and deletes bundles that exceed the defined limits.
-
-Two limits are available.
-Both are optional and can be combined:
-
-| Setting | Description | Default |
-| --- | --- | --- |
-| `max_deployments` | Maximum number of bundles to keep per content item | `20` |
-| `max_age_days` | Delete bundles older than this many days | No limit |
-
-<Aside type="note">
-The latest successful deployment is always protected—it will never be deleted regardless of policy.
-Pending deployments are also excluded from cleanup.
-</Aside>
-
-## Policy resolution
-
-Retention settings can be configured at two levels:
-
-1. **Server-wide**: in `ricochet-config.toml`, under the `[retention]` section. Applies to all content items.
-2. **Per-content**: in the content item's `_ricochet.toml`, under the `[retention]` section. Overrides the server default for that item.
-
-When both are configured, ricochet applies the **stricter** of the two values.
-A per-content policy can tighten the server default but cannot relax it.
-
-If no retention settings are configured at either level, bundles accumulate without limit.
-
-### Server-wide configuration
-
-Set defaults for all content items in `ricochet-config.toml`:
-
-```toml
-[retention]
-max_deployments = 20
-max_age_days = 90
-```
-
-### Per-content configuration
+## Per-content configuration
 
 Override the server default for a specific content item in its `_ricochet.toml`:
 
@@ -59,3 +24,6 @@ Override the server default for a specific content item in its `_ricochet.toml`:
 max_deployments = 5
 max_age_days = 30
 ```
+
+When both a server-wide and a per-content policy are configured, ricochet applies the **stricter** of the two values.
+A per-content policy can tighten the server default but cannot relax it.

--- a/src/content/docs/v0-10/admin/pricing/5-community-edition.mdx
+++ b/src/content/docs/v0-10/admin/pricing/5-community-edition.mdx
@@ -35,14 +35,14 @@ These boundaries exist to keep that distinction honest and sustainable:
 - **Up to 5 Git-based deployments:** because large-scale GitOps workflows are an enterprise concern.
 - **Up to 5 scheduled tasks**: scheduling at scale is part of enterprise operations.
 
-We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet’s automation and workflow capabilities.
-These features are intentionally capped to demonstrate what’s possible, without turning the Community Edition into a full enterprise platform.
+We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet's automation and workflow capabilities.
+These features are intentionally capped to demonstrate what's possible, without turning the Community Edition into a full enterprise platform.
 
 These limits are not about restricting what you can build—they exist to draw a clear, honest boundary between community usage and enterprise operations.
 
 ## Sustainability
 
-Ricochet’s free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
+Ricochet's free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
 At the same time, continuing to build, maintain, and improve ricochet requires a sustainable business.
 Our enterprise offerings fund development, operations, and support while investing back into the community and product.
 

--- a/src/content/docs/v0-8/admin/pricing/5-community-edition.mdx
+++ b/src/content/docs/v0-8/admin/pricing/5-community-edition.mdx
@@ -35,14 +35,14 @@ These boundaries exist to keep that distinction honest and sustainable:
 - **Up to 5 Git-based deployments:** because large-scale GitOps workflows are an enterprise concern.
 - **Up to 5 scheduled tasks**: scheduling at scale is part of enterprise operations.
 
-We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet’s automation and workflow capabilities.
-These features are intentionally capped to demonstrate what’s possible, without turning the Community Edition into a full enterprise platform.
+We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet's automation and workflow capabilities.
+These features are intentionally capped to demonstrate what's possible, without turning the Community Edition into a full enterprise platform.
 
 These limits are not about restricting what you can build—they exist to draw a clear, honest boundary between community usage and enterprise operations.
 
 ## Sustainability
 
-Ricochet’s free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
+Ricochet's free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
 At the same time, continuing to build, maintain, and improve ricochet requires a sustainable business.
 Our enterprise offerings fund development, operations, and support while investing back into the community and product.
 

--- a/src/content/docs/v0-9/admin/pricing/5-community-edition.mdx
+++ b/src/content/docs/v0-9/admin/pricing/5-community-edition.mdx
@@ -35,14 +35,14 @@ These boundaries exist to keep that distinction honest and sustainable:
 - **Up to 5 Git-based deployments:** because large-scale GitOps workflows are an enterprise concern.
 - **Up to 5 scheduled tasks**: scheduling at scale is part of enterprise operations.
 
-We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet’s automation and workflow capabilities.
-These features are intentionally capped to demonstrate what’s possible, without turning the Community Edition into a full enterprise platform.
+We include up to 5 Git-based deployments and 5 scheduled tasks so you can get a real taste of ricochet's automation and workflow capabilities.
+These features are intentionally capped to demonstrate what's possible, without turning the Community Edition into a full enterprise platform.
 
 These limits are not about restricting what you can build—they exist to draw a clear, honest boundary between community usage and enterprise operations.
 
 ## Sustainability
 
-Ricochet’s free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
+Ricochet's free offerings exist because we believe powerful tooling should be accessible to individuals and small teams.
 At the same time, continuing to build, maintain, and improve ricochet requires a sustainable business.
 Our enterprise offerings fund development, operations, and support while investing back into the community and product.
 


### PR DESCRIPTION
This PR documents the new `max_bundle_size` in the `ricochet-config.toml`. 

Additionally, it moves the bulk of the documentation regarding `[retention]` to the admin guide and leaves only a minimal section in the user guide. 