### PR TITLE
docs: add v0.16.0 release notes

### DIFF
--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -49,6 +49,7 @@ template: splash
 
 ### Server
 
+- [v0.16.0](/releases/v0.16.0/) - August 4, 2026
 - [v0.15.0](/releases/v0.15.0/) - July 22, 2026
 - [v0.14.1](/releases/v0.14.1/) - July 12, 2026
 - [v0.14.0](/releases/v0.14.0/) - July 8, 2026

--- a/src/content/docs/releases/v0.16.0.mdx
+++ b/src/content/docs/releases/v0.16.0.mdx
@@ -1,0 +1,37 @@
+---
+title: v0.16.0
+docs: release notes for Ricochet v0.16.0
+slug: releases/v0.16.0
+tableOfContents: false
+template: splash
+---
+
+**Released: August 4, 2026**
+
+### Features
+
+#### UI
+
+- **Navbar quick actions**: The navbar now includes direct links to the release notes and issue tracker, so you can check what changed or report a problem without leaving ricochet.
+
+### Fixes
+
+#### Core
+
+- **Rootless container-in-container**: ricochet now supports running inside a rootless container.
+- **Earlier tracing and logging**: Tracing and logging now start as early as possible during ricochet startup, so failures that happen before ricochet is fully started are captured in the logs.
+- **Deleted Content**: Cntent items are now deleted as a background task so that deletion occurrs promptly in the UI.
+
+#### UI
+
+- **Live view for static sites**: The "View live" action is now shown only when a static site has actually rendered HTML, so the link no longer leads to a missing page.
+- **Tooltips on disabled buttons**: Tooltips now render on disabled buttons, which previously showed no explanation of why an action was unavailable.
+
+#### Tasks
+
+- **Recovery without a successful deployment**: Tasks that have never deployed successfully now surface a clear error and a path to recover, instead of leaving you without next steps.
+
+#### Misc
+
+- **Process wait status**: Fixes a bug where some exit codes were incorrectly categorized as a successfull run.
+- **newuidmap dependency**: Packages now declare `newuidmap` as a required dependency, preventing installs that are missing it from failing at runtime.


### PR DESCRIPTION
Last item to close out v0.16.0 release from https://ci.ricochet.rs/repos/2/pipeline/4591/45